### PR TITLE
Upgrade Elixir to 1.5.1 in the buildpack

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -2,7 +2,7 @@
 erlang_version=18.2.1
 
 # Elixir version
-elixir_version=1.4.0
+elixir_version=1.5.1
 
 # Always rebuild from scratch on every deploy?
 always_rebuild=false


### PR DESCRIPTION
### Problem

The buildpack is still pegged to the old Elixir version:

```
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> Elixir app detected
remote: -----> Checking Erlang and Elixir versions
remote:        Will use the following versions:
remote:        * Stack heroku-16
remote:        * Erlang 18.2.1
remote:        * Elixir 1.4.0
```

We may have forgotten to do this in #22, which ensures that the Heroku buildpack matches the elixir version.

### Solution

Update the buildpack config to 1.5.1:

```
-----> Elixir app detected
-----> Checking Erlang and Elixir versions
       Will use the following versions:
       * Stack heroku-16
       * Erlang 18.2.1
       * Elixir 1.5.1 
```