### PR TITLE
Found a couple of typos

### DIFF
--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,5 +1,5 @@
 defmodule AppPrototype.Factory do
-  use ExMachina.Ecto, repo: AppPrototyp.Repo
+  use ExMachina.Ecto, repo: AppPrototype.Repo
   # Sample user factory
   # def user_factory do
   #   %User{

--- a/web/templates/layout/app.html.slim
+++ b/web/templates/layout/app.html.slim
@@ -51,4 +51,4 @@ html lang="en"
 
     footer
       .container
-        p &copy; App Protype, All rights reserved.
+        p &copy; AppPrototype, All rights reserved.


### PR DESCRIPTION
I believe that renaming these to `AppPrototype` will allow them to be replaced by the generated app name - @craiglyons can you confirm?