### PR TITLE
Add release stage to Procfile to run migrations when deploying to heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: POOL_SIZE=2 MIX_ENV=$MIX_ENV mix ecto.migrate
 web: MIX_ENV=$MIX_ENV mix phoenix.server

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Now you're ready to remove demo content, which is easy to spot from the landing 
     * `MIX_ENV` should be `acceptance` and `prod` respectively
     * `POOL_SIZE` should be set 2 units below the max db connections allowed by the Heroku instance. This allows mix tasks to be run with 2 connections.
     * `DATABASE_URL` should have been filled automatically by provisioning heroku postgres.
+  * Migrations are run automatically using Heroku's [release phase](https://devcenter.heroku.com/articles/release-phase).
 
 
 


### PR DESCRIPTION
You can use the [release phase](https://devcenter.heroku.com/articles/release-phase) to run migrations on heroku. This fix assumes that you have a default `POOL_SIZE` environment variable set to 18 and that the ecto config uses the `POOL_SIZE` variable. Otherwise you'll overrun heroku's max allowed PG connections of 20. True to form, I didn't actually attempt to confirm any of this and instead I'm going to rely on @craiglyons to once again un-fuck any mistakes I've made :heart:.